### PR TITLE
Add Privacy Policy to Footer

### DIFF
--- a/searx/templates/oscar/base.html
+++ b/searx/templates/oscar/base.html
@@ -108,6 +108,7 @@
                     {{ _('search.privacytools.io is powered by') }} <a href="https://asciimoo.github.io/searx/">searx</a> - {{ searx_version }} - {{ _('a privacy-respecting metasearch engine') }}<br/>
                     <a href="https://github.com/privacytoolsIO/search">{{ _('Source code') }}</a> |
                     <a href="https://github.com/privacytoolsIO/search/issues">{{ _('Issue tracker') }}</a> |
+                    <a href="https://www.privacytools.io/privacy-policy.html">{{ _('Privacy policy') }}</a> |
                     {{ _('In collaboration with') }} <a href="https://www.opennic.org/">{{ _('OpenNIC') }}</a>
                 </small>
             </p>


### PR DESCRIPTION
Adds a link to the privacy policy page on `privacytools.io`. Do not merge until privacytoolsIO/privacytools.io#795 is committed.

---

Resolves: #3